### PR TITLE
Arrow obj patterns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/lib/es_tree/tools/generator.ex
+++ b/lib/es_tree/tools/generator.ex
@@ -231,7 +231,7 @@ defmodule ESTree.Tools.Generator do
       do_generate(body, opts)
     end
 
-    if not opts.beauty and length(ast.params) == 1 do
+    if not opts.beauty and length(ast.params) == 1 and hd(ast.params).__struct__ != ObjectPattern do
       [async, params, generator, wh_sep, "=>", wh_sep, body]
     else
       [async, "(", params, ")", generator, wh_sep, "=>", wh_sep, body]

--- a/test/tools/generator/arrow_function_expression_test.exs
+++ b/test/tools/generator/arrow_function_expression_test.exs
@@ -30,6 +30,19 @@ defmodule ESTree.Tools.Generator.ArrowFunctionExpression.Test do
     assert_gen ast, "()=>({})", beauty: false
   end
 
+  should "convert basic arrow function object pattern has parens" do
+    ast = Builder.arrow_function_expression(
+      [Builder.object_pattern([Builder.identifier(:one)])],
+      [],
+      Builder.block_statement([]),
+      false,
+      false
+    )
+
+    assert_gen ast, "({one}) => {}"
+    assert_gen ast, "({one})=>{}", beauty: false
+  end
+
   should "convert basic arrow function expression generator" do
     ast = Builder.arrow_function_expression(
       [],


### PR DESCRIPTION
it was incorrectly generating `{one}=>{}` which is invalid syntax and needs parens.

my editor needed the editorconfig... omit the last commit if you don't want it

thanks!