### PR TITLE
Allow for options to be customized

### DIFF
--- a/lib/es_tree/tools/generator.ex
+++ b/lib/es_tree/tools/generator.ex
@@ -145,9 +145,9 @@ defmodule ESTree.Tools.Generator do
     :">>>=" , :"|=" , :"^=" , :"&=", :++, :--
   ]
 
-  @spec generate(ESTree.operator | ESTree.Node.t, boolean) :: binary
-  def generate(value, beauty \\ true) do
-    opts = if beauty do
+  @spec generate(ESTree.operator | ESTree.Node.t, boolean | map) :: binary
+  def generate(value, beauty_or_opts \\ true) do
+    opts = if beauty_or_opts do
       %{
         beauty: true,
         wh_sep: " ",
@@ -169,6 +169,8 @@ defmodule ESTree.Tools.Generator do
         no_trailing_semicolon: false
       }
     )
+    
+    opts = if is_map(beauty_or_opts), do: Map.merge(opts, beauty_or_opts), else: opts
 
     value
     |> do_generate(opts)


### PR DESCRIPTION
Allow for options to be passed in as the second argument.

```elixir
value |> generate() # still works
value |> generate(true) # default behavior
value |> generate(false) # still supported
value |> generate(%{"indent_level" => 2}) # "beauty" => true is inferred, but can be overridden
```

This PR does not introduce any breaking changes, but allows to customize the configuration.